### PR TITLE
Fixed network connection

### DIFF
--- a/Assets/_MageBall/Scripts/MenuScripts/MainMenu.cs
+++ b/Assets/_MageBall/Scripts/MenuScripts/MainMenu.cs
@@ -60,7 +60,7 @@ namespace MageBall
         public void JoinGame()
         {
             string ipAddress = ipAddressInputField.text;
-
+            ipAddress = ipAddress.Trim();
             networkManager.networkAddress = ipAddress;
             networkManager.StartClient();
 


### PR DESCRIPTION
Ip address string is now trimmed from blank spaces before being passed as the network address. Fixes an "invisible" bug where if you copy the ip address you might have an extra blank space that might not be visible and that would make you unable to connect to the host despite the ip seemingly being entered correctly.