### PR TITLE
Ball and spell tweaks

### DIFF
--- a/Assets/_MageBall/Prefabs/Ball.prefab
+++ b/Assets/_MageBall/Prefabs/Ball.prefab
@@ -12,7 +12,8 @@ GameObject:
   - component: {fileID: 3085337723083032212}
   - component: {fileID: 3085337723083032213}
   - component: {fileID: 3085337723083032214}
-  - component: {fileID: 2633104025221200076}
+  - component: {fileID: 8402276572749556863}
+  - component: {fileID: 7386123596916984094}
   m_Layer: 7
   m_Name: Ball
   m_TagString: Ball
@@ -63,7 +64,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 2
 --- !u!114 &3085337723083032214
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -81,7 +82,7 @@ MonoBehaviour:
   visible: 0
   m_AssetId: 
   hasSpawned: 0
---- !u!114 &2633104025221200076
+--- !u!114 &8402276572749556863
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -103,6 +104,46 @@ MonoBehaviour:
   syncAngularVelocity: 1
   clearAngularVelocity: 0
   angularVelocitySensitivity: 0.1
+--- !u!114 &7386123596916984094
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3085337723083032233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 741bbe11f5357b44593b15c0d11b16bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  excludeOwnerUpdate: 1
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 0
+  interpolateRotation: 0
+  interpolateScale: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
+  lastPosition: {x: 0, y: 0, z: 0}
+  lastRotation: {x: 0, y: 0, z: 0, w: 0}
+  lastScale: {x: 0, y: 0, z: 0}
+  start:
+    timeStamp: 0
+    localPosition: {x: 0, y: 0, z: 0}
+    localRotation: {x: 0, y: 0, z: 0, w: 0}
+    localScale: {x: 0, y: 0, z: 0}
+    movementSpeed: 0
+  goal:
+    timeStamp: 0
+    localPosition: {x: 0, y: 0, z: 0}
+    localRotation: {x: 0, y: 0, z: 0, w: 0}
+    localScale: {x: 0, y: 0, z: 0}
+    movementSpeed: 0
 --- !u!1001 &791207834667505774
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_MageBall/Prefabs/MagicPrefab/ForcePushProjectile.prefab
+++ b/Assets/_MageBall/Prefabs/MagicPrefab/ForcePushProjectile.prefab
@@ -27,7 +27,7 @@ Transform:
   m_GameObject: {fileID: 2958128035698285669}
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children: []
   m_Father: {fileID: 3606733632085325172}
   m_RootOrder: 0
@@ -176,9 +176,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  flightSpeed: 60
-  radius: 5
-  explosionForce: 1000
+  flightSpeed: 50
+  radius: 8
+  explosionForce: 1500
 --- !u!114 &-8987871216110443510
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -215,7 +215,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 126
-  m_CollisionDetection: 0
+  m_CollisionDetection: 2
 --- !u!135 &4403369487306535221
 SphereCollider:
   m_ObjectHideFlags: 0
@@ -227,5 +227,5 @@ SphereCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.6
-  m_Center: {x: 0, y: 0, z: 0.8}
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/_MageBall/Prefabs/PlayerPrefabs/Player.prefab
+++ b/Assets/_MageBall/Prefabs/PlayerPrefabs/Player.prefab
@@ -210,7 +210,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 1
   syncInterval: 0
-  modifier: 30
+  modifier: 15
 --- !u!114 &2500617132447201991
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_MageBall/Scripts/ForcePull.cs
+++ b/Assets/_MageBall/Scripts/ForcePull.cs
@@ -8,13 +8,13 @@ namespace MageBall
     public class ForcePull : Spell
     {
 
-        [SerializeField]
-        private float modifier = 30.0f;
+        [SerializeField] private float modifier = 15.0f;
+        [SerializeField] private float hitRadius = 0.2f;
 
         [Command]
         public override void CmdCastSpell()
         {
-            if (Physics.Raycast(aimPosition, aimForward, out RaycastHit hit, Mathf.Infinity, LayerMasks.ballLayer))
+            if (Physics.SphereCast(aimPosition, hitRadius, aimForward, out RaycastHit hit, Mathf.Infinity, LayerMasks.ballLayer))
             {
                 Vector3 pullDirection = aimPosition - hit.transform.position;
                 Vector3 pullForce = pullDirection.normalized * modifier;

--- a/Assets/_MageBall/Scripts/ForcePushProjectile.cs
+++ b/Assets/_MageBall/Scripts/ForcePushProjectile.cs
@@ -25,7 +25,7 @@ namespace MageBall
 
         private void OnCollisionEnter(Collision collision)
         {
-            Vector3 explosionPoint = collision.GetContact(0).point;
+            Vector3 explosionPoint = transform.position;
             Collider[] colliders = Physics.OverlapSphere(explosionPoint, radius, LayerMasks.ballLayer | LayerMasks.groundLayer);
 
             foreach (Collider collider in colliders)

--- a/Assets/_MageBall/Scripts/MatchHandler.cs
+++ b/Assets/_MageBall/Scripts/MatchHandler.cs
@@ -64,17 +64,12 @@ namespace MageBall
                 networkGamePlayer.TargetResetPosition();
             }
 
-            RpcResetBall(ball);
+            ball.transform.position = ballStartPosition;
+            ball.transform.rotation = ballStartRotation;
             ballRigidbody.velocity = Vector3.zero;
             ballRigidbody.angularVelocity = Vector3.zero;
         }
 
-        [ClientRpc]
-        private void RpcResetBall(GameObject ball)
-        {
-            ball.transform.position = ballStartPosition;
-            ball.transform.rotation = ballStartRotation;
-        }
 
     }
 }


### PR DESCRIPTION
Changed force pull to sphere cast to be more forgiving, made force push explosion originate from transform position rather than contact point. Tweaked ball syncing and it seems to sync up better now - needs testing but the previous version lost sync and broke force pull aiming completely after a minute or two so it's most likely not worse than that. Changed ball collision detection mode so that it doesn't jump through the wall at high speeds.