### PR TITLE
Reset tweaks

### DIFF
--- a/Assets/_MageBall/Material/BallInner.mat
+++ b/Assets/_MageBall/Material/BallInner.mat
@@ -13,11 +13,10 @@ Material:
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
+  m_CustomRenderQueue: 2000
   stringTagMap:
-    RenderType: Transparent
-  disabledShaderPasses:
-  - SHADOWCASTER
+    RenderType: Opaque
+  disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -97,7 +96,7 @@ Material:
     - _Cutoff: 0.5
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
-    - _DstBlend: 1
+    - _DstBlend: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0
     - _Glossiness: 0
@@ -110,10 +109,10 @@ Material:
     - _Smoothness: 0.654
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 5
-    - _Surface: 1
+    - _SrcBlend: 1
+    - _Surface: 0
     - _WorkflowMode: 1
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - Color_02592cba7bb044bab26402c9d8da3c93: {r: 1, g: 1, b: 1, a: 0}
     - Color_14c4f41389ee4297917d4b5b9f0c02ec: {r: 0.3962264, g: 0.3962264, b: 0.3962264,

--- a/Assets/_MageBall/Prefabs/MagicPrefab/ForcePushProjectile.prefab
+++ b/Assets/_MageBall/Prefabs/MagicPrefab/ForcePushProjectile.prefab
@@ -125,7 +125,7 @@ GameObject:
   - component: {fileID: 4403369487306535221}
   m_Layer: 8
   m_Name: ForcePushProjectile
-  m_TagString: Untagged
+  m_TagString: Spell
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/_MageBall/Scripts/Goal.cs
+++ b/Assets/_MageBall/Scripts/Goal.cs
@@ -13,6 +13,8 @@ namespace MageBall
         private BoxCollider goalCollider;
         public event Action<Team> score;
 
+        public BoxCollider GoalCollider => goalCollider;
+
         public override void OnStartServer()
         {
             goalCollider = GetComponent<BoxCollider>();

--- a/Assets/_MageBall/Scripts/NetworkScripts/NetworkGamePlayerMageBall.cs
+++ b/Assets/_MageBall/Scripts/NetworkScripts/NetworkGamePlayerMageBall.cs
@@ -63,9 +63,13 @@ namespace MageBall
         }
 
         [TargetRpc]
-        public void TargetResetPosition()
+        public void TargetResetPlayer()
         {
+            if (playerGameObject == null)
+                return;
+
             playerGameObject.GetComponent<PlayerMovement>().enabled = false;
+            playerGameObject.GetComponent<Spellcasting>().enabled = false;
             playerGameObject.transform.position = spawnPosition;
             playerGameObject.transform.rotation = spawnRotation;
             StartCoroutine(EnablePlayerControls());
@@ -77,8 +81,9 @@ namespace MageBall
             if (playerGameObject == null)
                 yield break;
 
-            yield return new WaitForSeconds(1);
+            yield return new WaitForSeconds(NetworkManager.WaitBeforeControlsEnableInSeconds);
             playerGameObject.GetComponent<PlayerMovement>().enabled = true;
+            playerGameObject.GetComponent<Spellcasting>().enabled = true;
         }
     }
 }

--- a/Assets/_MageBall/Scripts/NetworkScripts/NetworkManagerMageBall.cs
+++ b/Assets/_MageBall/Scripts/NetworkScripts/NetworkManagerMageBall.cs
@@ -19,6 +19,12 @@ namespace MageBall
         [SerializeField] private NetworkGamePlayerMageBall gamePlayerPrefab;
         [SerializeField] private GameObject playerSpawnSystem;
 
+        [Header("Settings")]
+        [SerializeField, Tooltip("The time in seconds before a player gains control of their character at the start of the game and after goals.")] 
+        private float waitBeforeControlsEnableInSeconds = 3;
+        [SerializeField, Tooltip("The time in seconds before a reset occurs after a goal.")]
+        private float waitBeforeResetAfterGoalInSeconds = 1.5f;
+
         private string arenaPrefix = "Arena_";
 
         public static event Action clientConnected;
@@ -28,6 +34,8 @@ namespace MageBall
 
         public List<NetworkRoomPlayerMageBall> NetworkRoomPlayers { get; } = new List<NetworkRoomPlayerMageBall>();
         public List<NetworkGamePlayerMageBall> NetworkGamePlayers { get; } = new List<NetworkGamePlayerMageBall>();
+        public float WaitBeforeControlsEnableInSeconds => waitBeforeControlsEnableInSeconds;
+        public float WaitBeforeResetAfterGoalInSeconds => waitBeforeResetAfterGoalInSeconds;
 
         public override void OnClientConnect(NetworkConnection conn)
         {

--- a/Assets/_MageBall/Scripts/Tags.cs
+++ b/Assets/_MageBall/Scripts/Tags.cs
@@ -7,5 +7,6 @@ public static class Tags
 
     public static readonly string BallTag = "Ball";
     public static readonly string PlayerTag = "Player";
+    public static readonly string SpellTag = "Spell";
 
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Ground
   - Ball
+  - Spell
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Tweaked reset:
The game now waits a second before resetting
Goal colliders are now disabled after a goal is scored
The game now waits three seconds after a reset to allow the player to control their character
Spellcasting is now also disabled after a reset
Spells are now destroyed after a reset.
Ball gravity and mass is now also reset