### PR TITLE
Added a delay before audio starts playing when pressing join game

### DIFF
--- a/Assets/_MageBall/Scripts/MenuScripts/MainMenu.cs
+++ b/Assets/_MageBall/Scripts/MenuScripts/MainMenu.cs
@@ -1,4 +1,5 @@
 using Mirror;
+using System.Collections;
 using TMPro;
 using UnityEngine;
 
@@ -115,6 +116,16 @@ namespace MageBall
 
             menuButtonController.DeactivateButtons();
             attemptingConnectionPanel.SetActive(true);
+            AudioSource waitMusicSource = attemptingConnectionPanel.GetComponent<AudioSource>();
+            StartCoroutine(PlayAudioWithDelay(waitMusicSource, 0.1f));
+        }
+
+        private IEnumerator PlayAudioWithDelay(AudioSource source, float delayInSeconds)
+        {
+            source.Stop();
+            yield return new WaitForSeconds(delayInSeconds);
+            if(source.isActiveAndEnabled)
+                source.Play();
         }
 
         public void OpenOptionsMenu()


### PR DESCRIPTION
This makes it so that the audio doesn't play loudly for a few milliseconds when a client presses and joins a game successfully which was quite jarring.